### PR TITLE
Increase the size of xtb4stdahome

### DIFF
--- a/include/setcommon.fh
+++ b/include/setcommon.fh
@@ -29,7 +29,7 @@
       logical rdset,enan_siman,honly,nvt_md,restart_md,fit,lmo,tsopt,
      .        shake_md,moldfile,mdrtrconstr,check_rmsd,velodump,samerand
       character*80 inputname
-      character*80 xtb4stdahome   
+      character*150 xtb4stdahome   
       character*20 solvent
       character*4  pgroup 
       character*80 orcaexe,orcaline,molnameline,commentline

--- a/src/gbobc.f
+++ b/src/gbobc.f
@@ -191,7 +191,7 @@ c     Gshift (gsolv=reference vs. gsolv)
       real*8 :: gamma_in, rvdwscal, tmp(94), gstate, dum, temp
       character*80 fname
       logical ex
-      character*80 a80
+      character*200 a200
 
 c     D3 cut-off radii
       rvdw(1:94)= (/
@@ -227,8 +227,8 @@ c     hydrogen bonding parameters
       rvdwscal=1.0d0
 
       write(fname,'(''.param_gbsa_'',a)')trim(sname)
-      a80=trim(XTB4STDAHOME) // trim(fname)
-      fname=a80
+      a200=trim(XTB4STDAHOME) // trim(fname)
+      fname=a200
       write(*,*) 'Solvent             : ', trim(sname)
       write(*,*) 'GBSA parameter file : ', trim(fname)
 
@@ -255,15 +255,15 @@ c               RT*(ln(ideal gas mol volume)+ln(rho/M))
      .       log(1000.0d0*rhos/smass))
          gshift=(gshift+gstate)/autokcal
          write(*,*) 'Gsolv state corr. (kcal):',gstate
-         a80='gsolv=reference [X=1]'
+         a200='gsolv=reference [X=1]'
       elseif(mode.eq.0)then !gsolv option in COSMOTHERM to which it was fitted
          gshift=gshift/autokcal
-         a80='gsolv [1 M gas/solution]'
+         a200='gsolv [1 M gas/solution]'
       elseif(mode.eq.2)then ! 1 bar gas/ 1 M solution is not implemented in COSMOTHERM although its the canonical choice
          gstate=(temp*8.31451/1000./4.184)*log(24.79d0*temp/298.15)
          gshift=(gshift+gstate)/autokcal
          write(*,*) 'Gsolv state corr. (kcal):',gstate
-         a80='gsolv [1 bar gas/ 1 M solution]'
+         a200='gsolv [1 bar gas/ 1 M solution]'
       endif
 
       do i=1,94
@@ -307,7 +307,7 @@ c      inverse Debye screening length
       endif
 
 c     print parameters
-      write(*,*) 'Gsolv ref. state (COSMO-RS): ',trim(a80)
+      write(*,*) 'Gsolv ref. state (COSMO-RS): ',trim(a200)
       write(*,*) 'temperature (mdtemp)       : ',temp
       write(*,*) 'dielectric constant        : ',epsv
       write(*,*) 'rho                        : ',rhos

--- a/src/main.f
+++ b/src/main.f
@@ -42,7 +42,8 @@ c     include 'interface.f'
       integer,allocatable :: at(:)
       integer,allocatable :: frozh(:)
       real*8 xx(10),globpar(25)
-      character*80 fname,fnv,arg(20),fnx
+      character*80 fname,arg(20)
+      character*200 fnv,fnx
       character*128 atmp
       character*2 asym
 

--- a/src/molbld.f
+++ b/src/molbld.f
@@ -177,7 +177,7 @@ c     endif
       include 'spherecommon.fh'
       include 'atomlistcommon.fh'
 
-      character*128 line
+      character*200 line
       character*80  str
       character*2  asym
       real*8 xx(100),minmass,pi,phi,valijkl,ex_open_HS,ex_open_LS,rij(3)

--- a/src/readparam.f
+++ b/src/readparam.f
@@ -52,7 +52,7 @@ ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
       subroutine rdelparam(ini,fname,globpar,gfnver)
       implicit none
-      character*80 fname
+      character*200 fname
       real*8 globpar(25)
       integer ini,gfnver
       include 'aoelementcommon.fh'


### PR DESCRIPTION
when using [easybuild](https://easybuild.readthedocs.io/en/latest/), the path in `XTB4STDAHOME` can become quite large (due to very explicit naming conventions). For example,

```bash
$ echo $XTB4STDAHOME 
/home/pbeaujea/.local/easybuild/software/xtb4stda/1.0-intel-2018b/share/xtb4stda
```

This PR increase the size of the variables in the fortran code to allow longer paths.

I tested it on our cluster, it seems to work :-)