### PR TITLE
Add build options for Windows

### DIFF
--- a/MAKE/Makerules
+++ b/MAKE/Makerules
@@ -32,7 +32,7 @@ FC := ifort
 CC := icc
 
 # compile flags
-FCFLAGS := -O -axAVX -qopenmp -r8
+FCFLAGS := -O -axAVX -qopenmp -r8 -fpp
 FCFLAGS += -module $(MODDIR)
 FCFLAGS += -I$(INCDIR)                       \
            -I$(MKLROOT)/include/intel64/lp64 \

--- a/MAKE/Makerules
+++ b/MAKE/Makerules
@@ -32,7 +32,7 @@ FC := ifort
 CC := icc
 
 # compile flags
-FCFLAGS := -O -axAVX -qopenmp -r8 -fpp
+FCFLAGS := -O -axAVX -qopenmp -fpp -r8
 FCFLAGS += -module $(MODDIR)
 FCFLAGS += -I$(INCDIR)                       \
            -I$(MKLROOT)/include/intel64/lp64 \

--- a/meson.build
+++ b/meson.build
@@ -41,16 +41,29 @@ elif fc.get_id() == 'intel'
   if get_option('interface') == '64'
     add_project_arguments('-i8', language: 'fortran')
   endif
+elif fc.get_id() == 'intel-cl' # Windows with Intel Fortran
+  add_project_arguments('-QaxAVX2',    language: 'fortran')
+  add_project_arguments('-traceback', language: 'fortran')
+  if get_option('static')
+    add_project_arguments('-MT', language: 'fortran') # link to static Fortran library
+  endif
+  if get_option('interface') == '64'
+    add_project_arguments('-4I8', language: 'fortran')
+  endif
 endif
 
 dependencies = []
 
 la_backend = get_option('la_backend')
 if la_backend == 'mkl'
-  libmkl = [fc.find_library('pthread')]
-  libmkl += fc.find_library('m')
-  libmkl += fc.find_library('dl')
-  if fc.get_id() == 'intel'
+  if host_machine.system() == 'windows'
+    libmkl = [fc.find_library('libiomp5md')]
+  else
+    libmkl = [fc.find_library('pthread')]
+    libmkl += fc.find_library('m')
+    libmkl += fc.find_library('dl')
+  endif
+  if (fc.get_id() == 'intel') or (fc.get_id() == 'intel-cl')
     if get_option('interface') == '64'
       libmkl += fc.find_library('mkl_intel_ilp64')
     else
@@ -66,7 +79,9 @@ if la_backend == 'mkl'
     libmkl += fc.find_library('mkl_gnu_thread')
   endif
   libmkl += fc.find_library('mkl_core')
-  libmkl += fc.find_library('iomp5')
+  if host_machine.system() != 'windows'
+    libmkl += fc.find_library('iomp5')
+  endif
   dependencies += libmkl
 elif la_backend == 'openblas'
   dependencies += fc.find_library('openblas', required : true)
@@ -84,6 +99,8 @@ if get_option('openmp')
   if fc.get_id() == 'intel'
     add_project_arguments('-qopenmp', language : 'fortran')
     add_project_link_arguments('-qopenmp', language : 'fortran')
+  elif fc.get_id() == 'intel-cl'
+    add_project_arguments('-Qopenmp', language : 'fortran')
   else
     add_project_arguments('-fopenmp', language : 'fortran')
     add_project_link_arguments('-fopenmp', language : 'fortran')

--- a/meson.build
+++ b/meson.build
@@ -28,12 +28,14 @@ fc = meson.get_compiler('fortran')
 
 if fc.get_id() == 'gcc'
   add_project_arguments('-ffree-line-length-none', language: 'fortran')
+  add_project_arguments('-cpp', language: 'fortran')
   add_project_arguments('-fbacktrace', language: 'fortran')
   if get_option('interface') == '64'
     add_project_arguments('-fdefault-integer-8', language: 'fortran')
   endif
 elif fc.get_id() == 'intel'
   add_project_arguments('-axAVX2',    language: 'fortran')
+  add_project_arguments('-fpp',    language: 'fortran')
   add_project_arguments('-traceback', language: 'fortran')
   if get_option('static')
     add_project_link_arguments('-static', language: 'fortran')
@@ -43,6 +45,7 @@ elif fc.get_id() == 'intel'
   endif
 elif fc.get_id() == 'intel-cl' # Windows with Intel Fortran
   add_project_arguments('-QaxCORE-AVX2',    language: 'fortran')
+  add_project_arguments('-fpp',    language: 'fortran')
   add_project_arguments('-traceback', language: 'fortran')
   if get_option('static')
     add_project_arguments('-MT', language: 'fortran') # link to static Fortran library

--- a/meson.build
+++ b/meson.build
@@ -42,7 +42,7 @@ elif fc.get_id() == 'intel'
     add_project_arguments('-i8', language: 'fortran')
   endif
 elif fc.get_id() == 'intel-cl' # Windows with Intel Fortran
-  add_project_arguments('-QaxAVX2',    language: 'fortran')
+  add_project_arguments('-QaxCORE-AVX2',    language: 'fortran')
   add_project_arguments('-traceback', language: 'fortran')
   if get_option('static')
     add_project_arguments('-MT', language: 'fortran') # link to static Fortran library

--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,9 @@ if fc.get_id() == 'gcc'
 elif fc.get_id() == 'intel'
   add_project_arguments('-axAVX2',    language: 'fortran')
   add_project_arguments('-fpp',    language: 'fortran')
-  add_project_arguments('-traceback', language: 'fortran')
+  if get_option('buildtype') == 'debug'
+    add_project_arguments('-traceback', language: 'fortran')
+  endif
   if get_option('static')
     add_project_link_arguments('-static', language: 'fortran')
   endif
@@ -46,7 +48,9 @@ elif fc.get_id() == 'intel'
 elif fc.get_id() == 'intel-cl' # Windows with Intel Fortran
   add_project_arguments('-QaxCORE-AVX2',    language: 'fortran')
   add_project_arguments('-fpp',    language: 'fortran')
-  add_project_arguments('-traceback', language: 'fortran')
+  if get_option('buildtype') == 'debug'
+    add_project_arguments('-traceback', language: 'fortran')
+  endif
   if get_option('static')
     add_project_arguments('-MT', language: 'fortran') # link to static Fortran library
   endif

--- a/src/uxtb.f
+++ b/src/uxtb.f
@@ -527,7 +527,11 @@ c       fitting stuff for charge TB
             goto 130
          endif
          call docm5(n,at,.false.,xyz,chir,cm5_true)
+#if defined(_WIN32) || defined (_WIN64)
+         call execute_command_line('cd>tmpxtb2')
+#else
          call execute_command_line('pwd > tmpxtb2')
+#endif
          open(unit=43,file='tmpxtb2')
          read(43,'(a)') ftmp
          close(43,status='delete')

--- a/src/xtb.f
+++ b/src/xtb.f
@@ -448,7 +448,11 @@ c       Mulliken pop
 c       fitting stuff for charge TB
         if(ex)then
 c        fitting stuff
+#if defined(_WIN32) || defined(_WIN64)
+         call execute_command_line('cd>tmpxtb2')
+#else
          call execute_command_line('pwd > tmpxtb2')
+#endif
          open(unit=43,file='tmpxtb2')
          read(43,'(a)') ftmp
          close(43,status='delete')


### PR DESCRIPTION
This PR aims to make xtb4stda compilable on Windows.

Fixed some command line calls from within Fortran code, and changed the meson build script to provide correct compiler arguments for Intel Fortran on Windows.

The command line calls are guarded with `#if defined`, so preprocessing is turned on during compiling.